### PR TITLE
Make the formset layout more crispy ;-)

### DIFF
--- a/mycollections/forms.py
+++ b/mycollections/forms.py
@@ -1,9 +1,11 @@
 from django import forms
-from .models import *
+from .models import Collection, CollectionTitle
 from django.forms.models import inlineformset_factory
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Field, Fieldset, Div, HTML, ButtonHolder, Submit
-from .custom_layout_object import *
+from crispy_forms.layout import Layout, Field, Fieldset, Div, Row, HTML, ButtonHolder, Submit
+from .custom_layout_object import Formset
+
+import re
 
 
 class CollectionTitleForm(forms.ModelForm):
@@ -12,10 +14,27 @@ class CollectionTitleForm(forms.ModelForm):
         model = CollectionTitle
         exclude = ()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        formtag_prefix = re.sub('-[0-9]+$', '', kwargs.get('prefix', ''))
+
+        self.helper = FormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = Layout(
+            Row(
+                Field('name'),
+                Field('language'),
+                Field('DELETE'),
+                css_class='formset_row-{}'.format(formtag_prefix)
+            )
+        )
+
+
 CollectionTitleFormSet = inlineformset_factory(
     Collection, CollectionTitle, form=CollectionTitleForm,
     fields=['name', 'language'], extra=1, can_delete=True
-    )
+)
 
 
 class CollectionForm(forms.ModelForm):
@@ -36,9 +55,9 @@ class CollectionForm(forms.ModelForm):
                 Field('subject'),
                 Field('owner'),
                 Fieldset('Add titles',
-                    Formset('titles')),
+                         Formset('titles')),
                 Field('note'),
                 HTML("<br>"),
                 ButtonHolder(Submit('submit', 'Save')),
-                )
             )
+        )

--- a/mycollections/templates/mycollections/formset.html
+++ b/mycollections/templates/mycollections/formset.html
@@ -1,26 +1,21 @@
 {% load crispy_forms_tags %}
 {% load staticfiles %}
-<table class="col-md-9" style="margin-left: 10px;">
+
+<style type="text/css">
+  .delete-row {
+    align-self: center;
+  }
+</style>
+
 {{ formset.management_form|crispy }}
 
-    {% for form in formset.forms %}
-            <tr class="{% cycle 'row1' 'row2' %} formset_row-{{ formset.prefix }}">
-                {% for field in form.visible_fields %}
-                <td>
-                    {# Include the hidden fields in the form #}
-                    {% if forloop.first %}
-                        {% for hidden in form.hidden_fields %}
-                            {{ hidden }}
-                        {% endfor %}
-                    {% endif %}
-                    {{ field.errors.as_ul }}
-                    {{ field|as_crispy_field }}
-                </td>
-                {% endfor %}
-            </tr>
-    {% endfor %}
+{% for form in formset.forms %}
+  {% for hidden in form.hidden_fields %}
+    {{ hidden|as_crispy_field }}
+  {% endfor %}
+  {% crispy form %}
+{% endfor %}
 
-</table>
 <br>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="{% static 'mycollections/libraries/django-dynamic-formset/jquery.formset.js' %}"></script>


### PR DESCRIPTION
Instead of putting all the form layout stuff into the file ``formset.html`` it would a better solution is to add a ``LayoutHelper`` to the ``CollectionTitleForm``. The advantage is that the layout is now modified by ``crispy_forms`` applying the selected template pack (e.g. bootstrap4). Only the CSS ``.delete-row`` must be secified to center the remove button of the ``django-formset`` plugin because only a link is added if the containing element is not a HTML-table.